### PR TITLE
related #44. 添加online_install.sh脚本,普通用户安装使用更方便

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@
 
 ### （1）安装教程
 
-* 克隆 (`git clone https://github.com/wszqkzqk/deepin-wine-ubuntu.git`) 或[下载](https://github.com/wszqkzqk/deepin-wine-ubuntu/archive/master.zip)到本地。
-* 在中国推荐用下面的地址，速度更快： (`git clone https://gitee.com/wszqkzqk/deepin-wine-for-ubuntu.git`) 
+推荐使用在线安装脚本:
 
-* 方法1(推荐)：在终端中运行（授予可执行权限后）： `./install.sh` 。
-* 方法2：使用图形界面的软件包管理器按顺序安装所有 deb 文件。
+    wget -qO- https://raw.githubusercontent.com/wszqkzqk/deepin-wine-ubuntu/master/online_install.sh | bash -e
 
 
 ### （2）使用说明

--- a/online_install.sh
+++ b/online_install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+TMP_DIR="$(mktemp -d)"
+DOWNLOAD_URL_PREFIX="https://github.com/wszqkzqk/deepin-wine-ubuntu/blob/master"
+
+echo "开始下载deepin-wine安装包, 请稍后..."
+wget -P "${TMP_DIR}" --content-disposition -c -T10 --tries=10 -q --show-progress "${DOWNLOAD_URL_PREFIX}"/{1.1udis86_1.72-2_i386.deb,1.2deepin-fonts-wine_2.18-12_all.deb,2.1deepin-libwine_2.18-12_i386.deb,2.2deepin-libwine-dbg_2.18-12_i386.deb,2.3deepin-libwine-dev_2.18-12_i386.deb,3.1deepin-wine32_2.18-12_i386.deb,3.2deepin-wine32-preloader_2.18-12_i386.deb,3.3deepin-wine32-tools_2.18-12_i386.deb,4deepin-wine_2.18-12_all.deb,5deepin-wine-binfmt_2.18-12_all.deb,6.1deepin-wine-plugin_1.0deepin2_amd64.deb,6.2deepin-wine-plugin-virtual_1.0deepin1_all.deb,7deepin-wine-helper_1.1deepin12_i386.deb,8deepin-wine-uninstaller_0.1deepin2_i386.deb}"?raw=true"
+
+echo "正在安装, 请稍后"
+sudo dpkg --add-architecture i386
+sudo apt update && sudo apt install -y "${TMP_DIR}"/*.deb
+
+echo "安装完毕
+您可以访问: https://gitee.com/wszqkzqk/deepin-wine-containers-for-ubuntu/
+下载您需要的deepin wine container"


### PR DESCRIPTION
添加`online_install.sh`以及相关的README说明。主要描述参考 #44 

个人建议将这些二进制下载统一放到`Release`页面，用github的或者码云的都可以，仓库存储这样一个脚本方便将deb包更新到release页面。这样我这个脚本也好处理，用wget直接下载最新release页面上所有的deb就可以了，而不是每次变了包名或者版本号都需要手工改脚本。