### PR TITLE
更新online_install.sh脚本，使用Release地址安装

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@
 
 ### （1）安装教程
 
+#### 在线安装
+
+直接使用在线安装脚本，安装最新的Release版本:
+
+```bash
+wget -qO- https://raw.githubusercontent.com/wszqkzqk/deepin-wine-ubuntu/master/online_install.sh | bash -e
+```
+
+#### 本地安装
+
 * 克隆 (`git clone https://github.com/wszqkzqk/deepin-wine-ubuntu.git`) 或[下载](https://github.com/wszqkzqk/deepin-wine-ubuntu/archive/master.zip)到本地。
 * 在中国推荐用下面的地址，速度更快： (`git clone https://gitee.com/wszqkzqk/deepin-wine-for-ubuntu.git`) 
 * 当然也可以选择下载releases：[Github](https://github.com/wszqkzqk/deepin-wine-ubuntu/releases) 或者

--- a/online_install.sh
+++ b/online_install.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -e
 
 TMP_DIR="$(mktemp -d)"
-DOWNLOAD_URL_PREFIX="https://github.com/wszqkzqk/deepin-wine-ubuntu/blob/master"
+RELEASE_ASSERTS_URL="$(wget -qO- -T10 --tries=10 --retry-connrefused https://api.github.com/repos/wszqkzqk/deepin-wine-ubuntu/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
 
-echo "开始下载deepin-wine安装包, 请稍后..."
-wget -P "${TMP_DIR}" --content-disposition -c -T10 --tries=10 -q --show-progress "${DOWNLOAD_URL_PREFIX}"/{1.1udis86_1.72-2_i386.deb,1.2deepin-fonts-wine_2.18-12_all.deb,2.1deepin-libwine_2.18-12_i386.deb,2.2deepin-libwine-dbg_2.18-12_i386.deb,2.3deepin-libwine-dev_2.18-12_i386.deb,3.1deepin-wine32_2.18-12_i386.deb,3.2deepin-wine32-preloader_2.18-12_i386.deb,3.3deepin-wine32-tools_2.18-12_i386.deb,4deepin-wine_2.18-12_all.deb,5deepin-wine-binfmt_2.18-12_all.deb,6.1deepin-wine-plugin_1.0deepin2_amd64.deb,6.2deepin-wine-plugin-virtual_1.0deepin1_all.deb,7deepin-wine-helper_1.1deepin12_i386.deb,8deepin-wine-uninstaller_0.1deepin2_i386.deb}"?raw=true"
+echo "开始下载deepin-wine安装包: ${RELEASE_ASSERTS_URL}, 请稍后..."
+cd "${TMP_DIR}"
+wget -c -T10 --tries=10 --show-progress -qO- "${RELEASE_ASSERTS_URL}" | tar zxf -
 
-echo "正在安装, 请稍后"
+echo "正在安装, 请稍后(需要sudo提权)"
 sudo dpkg --add-architecture i386
 sudo apt update && sudo apt install -y "${TMP_DIR}"/*.deb
 


### PR DESCRIPTION
发现上游仓库已经使用Release了，所以将脚本改用Release页面下载