### PR TITLE
关于Ubuntu/Debian下面的软件卸载方面

### DIFF
--- a/uninstall-ALL.sh
+++ b/uninstall-ALL.sh
@@ -1,0 +1,18 @@
+#/bin/bash
+# Author：IITII
+echo "如果您想完全卸载 deep-wine 和 32位软件包 并且 移除 32位 支持的话，"
+echo "如果您已知可能发生的后果的话，"
+echo "输入 1 继续，输入 0 退出："
+read i
+if [ $i -eq 1 ]; then
+    echo "移除32位软件包..."
+    sudo apt-get remove --purge $(dpkg --get-selections | grep i386 | awk '{print $1}')
+    echo "移除 32位 支持..."
+    sudo dpkg --remove-architecture i386
+elif [ $i -eq 0 ]; then
+    echo "操作取消..."
+    exit 0
+else
+    echo "请输入正确的数字!!"
+    exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 echo '正在准备卸载...'
-sudo apt remove *deepin*wine* udis86
-sudo apt autoremove
+sudo apt-get purge `dpkg --get-selections | grep deepin | grep wine | awk '{print $1}'`
+sudo apt remove --purge udis86
+# sudo apt autoremove
 echo '卸载完成...'
+echo -e "如果您不是双显卡用户的话，请手动执行： sudo apt autoremove 来清除不必要的依赖。\n如果您是双显卡用户的话，请勿在您不清楚的情况下执行该条命令，可能导致显卡驱动的丢失！"


### PR DESCRIPTION
1. 在 Ubuntu 18.04上执行 **原来的 uninstall.sh** ，用处不大，wineQQ甚至还可以正常运行。。
1. `uninstall.sh` 修改了卸载程序包的方法，使得 **卸载得更加干净** ，脚本适用性更广，更合理
2. 使用 `uninstall-ALL.sh` 脚本来 **删除所有 32位软件包** 和 **清除32位支持** ， **彻底卸载**