### PR TITLE
添加文泉驿字体依赖要求

### DIFF
--- a/deepin-libwine_2.18-12_i386/DEBIAN/control
+++ b/deepin-libwine_2.18-12_i386/DEBIAN/control
@@ -4,8 +4,8 @@ Version: 2.18-12
 Architecture: i386
 Maintainer: Debian Wine Party <pkg-wine-party@lists.alioth.debian.org>
 Installed-Size: 179996
-Depends: libasound2 (>= 1.0.16), libc6 (>= 2.23), libgcc1 (>= 1:3.0), liblcms2-2 (>= 2.2+git20110628), libldap-2.4-2 (>= 2.4.7), libmpg123-0 (>= 1.13.7), libopenal1 (>= 1.14), libpcap0.8 (>= 0.9.8), libpulse0 (>= 0.99.1), libstdc++6 (>= 5), libudev1 (>= 183), libusb-1.0-0 (>= 2:1.0.16), libx11-6, libxext6, libxml2 (>= 2.9.0), ocl-icd-libopencl1 | libopencl1, ocl-icd-libopencl1 (>= 1.0) | libopencl-1.1-1, udis86, zlib1g (>= 1:1.1.4), libxcursor1, libxi6, libxxf86vm1, libxrender1, libxrandr2, libxfixes3, libxinerama1, libxcomposite1, libgl1-mesa-glx, libglu1-mesa, libosmesa6, libxslt1.1, libdbus-1-3, libgnutls30, libncurses5, libv4l-0, libfreetype6, libcups2, libfontconfig1, libgsm1, libjpeg-turbo8, libpng16-16, libtiff5, libodbc1, fonts-liberation, deepin-fonts-wine
-Suggests: cups-bsd, ttf-mscorefonts-installer, fonts-wqy-microhei, fonts-wqy-zenhei
+Depends: libasound2 (>= 1.0.16), libc6 (>= 2.23), libgcc1 (>= 1:3.0), liblcms2-2 (>= 2.2+git20110628), libldap-2.4-2 (>= 2.4.7), libmpg123-0 (>= 1.13.7), libopenal1 (>= 1.14), libpcap0.8 (>= 0.9.8), libpulse0 (>= 0.99.1), libstdc++6 (>= 5), libudev1 (>= 183), libusb-1.0-0 (>= 2:1.0.16), libx11-6, libxext6, libxml2 (>= 2.9.0), ocl-icd-libopencl1 | libopencl1, ocl-icd-libopencl1 (>= 1.0) | libopencl-1.1-1, udis86, zlib1g (>= 1:1.1.4), libxcursor1, libxi6, libxxf86vm1, libxrender1, libxrandr2, libxfixes3, libxinerama1, libxcomposite1, libgl1-mesa-glx, libglu1-mesa, libosmesa6, libxslt1.1, libdbus-1-3, libgnutls30, libncurses5, libv4l-0, libfreetype6, libcups2, libfontconfig1, libgsm1, libjpeg-turbo8, libpng16-16, libtiff5, libodbc1, fonts-liberation, deepin-fonts-wine, fonts-wqy-microhei, fonts-wqy-zenhei
+Suggests: cups-bsd, ttf-mscorefonts-installer
 Built-Using: khronos-api (= 0~svn29735-1.1), unicode-data (= 9.0-1)
 Section: libs
 Priority: optional

--- a/deepin-libwine_2.18-12_i386/DEBIAN/control
+++ b/deepin-libwine_2.18-12_i386/DEBIAN/control
@@ -5,7 +5,7 @@ Architecture: i386
 Maintainer: Debian Wine Party <pkg-wine-party@lists.alioth.debian.org>
 Installed-Size: 179996
 Depends: libasound2 (>= 1.0.16), libc6 (>= 2.23), libgcc1 (>= 1:3.0), liblcms2-2 (>= 2.2+git20110628), libldap-2.4-2 (>= 2.4.7), libmpg123-0 (>= 1.13.7), libopenal1 (>= 1.14), libpcap0.8 (>= 0.9.8), libpulse0 (>= 0.99.1), libstdc++6 (>= 5), libudev1 (>= 183), libusb-1.0-0 (>= 2:1.0.16), libx11-6, libxext6, libxml2 (>= 2.9.0), ocl-icd-libopencl1 | libopencl1, ocl-icd-libopencl1 (>= 1.0) | libopencl-1.1-1, udis86, zlib1g (>= 1:1.1.4), libxcursor1, libxi6, libxxf86vm1, libxrender1, libxrandr2, libxfixes3, libxinerama1, libxcomposite1, libgl1-mesa-glx, libglu1-mesa, libosmesa6, libxslt1.1, libdbus-1-3, libgnutls30, libncurses5, libv4l-0, libfreetype6, libcups2, libfontconfig1, libgsm1, libjpeg-turbo8, libpng16-16, libtiff5, libodbc1, fonts-liberation, deepin-fonts-wine
-Suggests: cups-bsd, ttf-mscorefonts-installer
+Suggests: cups-bsd, ttf-mscorefonts-installer, fonts-wqy-microhei, fonts-wqy-zenhei
 Built-Using: khronos-api (= 0~svn29735-1.1), unicode-data (= 9.0-1)
 Section: libs
 Priority: optional


### PR DESCRIPTION
### 原因
Ubuntu现在已经不自带文泉驿字体作为简体中文字体, 改用更通用的Noto字体. 然而deepin wine的许多软件依赖文泉驿字体, 且无字体回落, 依赖缺失时, 中文会显示为实心方块.

### 说明
添加文泉驿字体依赖要求, 为`fonts-wqy-microhei, fonts-wqy-zenhei`, 所有Canonical现正支援的Ubuntu版本官方源均有此包, 位于universe分支.

---------------------------

请测试后再merge, .deb文件使用`dpkg -b`指令生成.